### PR TITLE
chore: replace hardcoded status check in Update notifs.ts

### DIFF
--- a/src/lib/notifs.ts
+++ b/src/lib/notifs.ts
@@ -45,7 +45,7 @@ export async function sendFrameNotification({
 
   const responseJson = await response.json();
 
-  if (response.status === 200) {
+  if (response.ok) {
     const responseBody = sendNotificationResponseSchema.safeParse(responseJson);
     if (responseBody.success === false) {
       // Malformed response


### PR DESCRIPTION
I noticed we were using a hardcoded check for status `200` in the code. To make it more robust and handle all successful responses (2xx), I replaced it with `response.ok`.

This ensures the code works correctly for other success statuses like `201` or `204` as well.  

Changes made:  
- Replaced `response.status === 200` with `response.ok`.  

This should improve reliability without changing the intended behavior.