### PR TITLE
chrore: Fix inconsistent indentation in content array

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,24 +1,24 @@
 import type { Config } from "tailwindcss";
 
 export default {
-    darkMode: ["class"],
-    content: [
+  darkMode: ["class"],
+  content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-  	extend: {
-  		colors: {
-  			background: 'var(--background)',
-  			foreground: 'var(--foreground)'
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		}
-  	}
+    extend: {
+      colors: {
+        background: 'var(--background)',
+        foreground: 'var(--foreground)'
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)'
+      }
+    }
   },
   plugins: [require("tailwindcss-animate")],
 } satisfies Config;


### PR DESCRIPTION
The indentation in the `content` array doesn't match the overall code style (2 spaces).
I've aligned the indentation to use 2 spaces consistently, ensuring it follows the project's coding standards.